### PR TITLE
Nicer Happy Path Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,4 @@ jobs:
       # the sudo requirement related to bind mounts.
       - stage:   test
         sudo:    true
-        install: make build csc etcd
-        script:  sudo make test
+        script:  make docker-test

--- a/service/controller.go
+++ b/service/controller.go
@@ -182,7 +182,7 @@ func (s *service) ControllerPublishVolume(
 
 	// Get the mount info to determine if the volume dir is already
 	// bind mounted to the device dir.
-	minfo, err := gofsutil.GetMounts(ctx)
+	minfo, err := getMounts(ctx)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal, "failed to get mount info: %v", err)
@@ -228,7 +228,7 @@ func (s *service) ControllerUnpublishVolume(
 	devPath := path.Join(s.dev, req.VolumeId)
 
 	// Get the node's mount information.
-	minfo, err := gofsutil.GetMounts(ctx)
+	minfo, err := getMounts(ctx)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal, "failed to get mount info: %v", err)


### PR DESCRIPTION
The Makefile target `test` now executes its happy path workflow with friendlier output. For example:

```shell
$ make test
CLEANUP
- verified volume not mounted
- verified volume paths do not exist
- killed etcd
- removed etcd log file & data directory
- killed csi-vfs
- removed csi-vfs log file & unix socket
- test environment ready

INITIALIZATION
- started etcd
- started csi-vfs
- csi-vfs ready

GET SUPPORTED VERSIONS
./csc -v 0.1.0 i version
0.0.0
0.1.0

GET PLUG-IN INFO
./csc -v 0.1.0 i info
"com.thecodeteam.vfs"	"0.2.1"

CREATE NEW VOLUME
./csc -v 0.1.0 c new \
      --cap SINGLE_NODE_WRITER,mount,vfs \
      vol-00
"vol-00"	0

VERIFY VOLUME DIR
test -e "/Users/akutz/.csi-vfs/vol/vol-00" -a -e "/Users/akutz/.csi-vfs/vol/vol-00/.info.json"

CONTROLLER PUBLISH VOLUME
./csc -v 0.1.0 c publish \
      --cap SINGLE_NODE_WRITER,mount,vfs \
      --node-id localhost \
      vol-00
"vol-00"	"path"="/Users/akutz/.csi-vfs/dev/vol-00"

VERIFY DEVICE DIR
test -e "/Users/akutz/.csi-vfs/dev/vol-00" -a -e "/Users/akutz/.csi-vfs/dev/vol-00/.info.json"

VERIFY VOLUME->DEVICE BIND MOUNT
test "$((cat /proc/self/mountinfo 2> /dev/null || mount) | grep /Users/akutz/.csi-vfs/dev/vol-00)"

CREATE TARGET PATH
mkdir -p /tmp/vol-00

NODE PUBLISH VOLUME
./csc -v 0.1.0 n publish \
      --cap SINGLE_NODE_WRITER,mount,vfs \
      --target-path /tmp/vol-00 \
      --pub-info devPath=/Users/akutz/.csi-vfs/dev/vol-00 \
    vol-00
vol-00

VERIFY MOUNT DIR
test -e "/Users/akutz/.csi-vfs/mnt/vol-00" -a -e "/Users/akutz/.csi-vfs/mnt/vol-00/.info.json"

VERIFY DEVICE->MOUNT BIND MOUNT
test "$((cat /proc/self/mountinfo 2> /dev/null || mount) | grep /Users/akutz/.csi-vfs/mnt/vol-00)"

VERIFY MOUNT->TARGET BIND MOUNT
test "$((cat /proc/self/mountinfo 2> /dev/null || mount) | grep /tmp/vol-00)"

NODE UNPUBLISH VOLUME
./csc -v 0.1.0 n unpublish --target-path /tmp/vol-00 vol-00
vol-00

VERIFY ! MOUNT->TARGET BIND MOUNT
test ! "$((cat /proc/self/mountinfo 2> /dev/null || mount) | grep /tmp/vol-00)"

VERIFY ! DEVICE->MOUNT BIND MOUNT
test ! "$((cat /proc/self/mountinfo 2> /dev/null || mount) | grep /Users/akutz/.csi-vfs/mnt/vol-00)"

VERIFY ! MOUNT DIR
test ! -e "/Users/akutz/.csi-vfs/mnt/vol-00"

CONTROLLER UNPUBLISH VOLUME
./csc -v 0.1.0 c unpublish --node-id localhost vol-00
vol-00

VERIFY ! VOLUME->DEVICE BIND MOUNT
test ! "$((cat /proc/self/mountinfo 2> /dev/null || mount) | grep /Users/akutz/.csi-vfs/dev/vol-00)"

VERIFY ! DEVICE DIR
test ! -e "/Users/akutz/.csi-vfs/dev/vol-00"

CONTROLLER DELETE VOLUME
./csc -v 0.1.0 c delete vol-00
vol-00

VERIFY ! VOLUME DIR
test ! -e "/Users/akutz/.csi-vfs/vol/vol-00"
```